### PR TITLE
feat: 회원 모집 공고 생성 기능 구현(#3)

### DIFF
--- a/src/main/java/com/jeari/config/SecurityConfig.java
+++ b/src/main/java/com/jeari/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.jeari.config;
 
+import com.jeari.entity.ClubRole;
 import com.jeari.entity.UserRole;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +20,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 X
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 X
                 // .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 연결 (있다면)
-                .authorizeHttpRequests(auth -> auth
+                .authorizeHttpRequests(auth -> auth     // 인가
                         .requestMatchers(
                                 "/api/auth/login",       // 로그인 API (토큰 발급)
                                 "/api/token/refresh",    // 토큰 재발급
@@ -29,6 +30,9 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/club/create"
                         ).hasRole(UserRole.USER.name())
+                        .requestMatchers(
+                                "/clubs/{clubid}/recruitments"
+                        ).hasRole(ClubRole.PRESIDENT.name())
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/jeari/controller/RecruitmentController.java
+++ b/src/main/java/com/jeari/controller/RecruitmentController.java
@@ -1,0 +1,30 @@
+package com.jeari.controller;
+
+import com.jeari.dto.RecruitmentRequest;
+import com.jeari.service.RecruitmentService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
+
+@Controller
+@AllArgsConstructor
+public class RecruitmentController {
+
+    final private RecruitmentService recruitmentService;
+
+    @PostMapping("/clubs/{clubid}/recruitments")
+    public ResponseEntity<?> createRecruitment(@PathVariable Integer clubid, @Valid @RequestBody RecruitmentRequest req) {
+
+        Integer recruitmentId = recruitmentService.createRecruitment(clubid, req);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("recruitmentId", recruitmentId));
+    }
+}

--- a/src/main/java/com/jeari/dto/RecruitmentRequest.java
+++ b/src/main/java/com/jeari/dto/RecruitmentRequest.java
@@ -1,0 +1,42 @@
+package com.jeari.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jeari.entity.RecruitmentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record RecruitmentRequest(
+        @NotNull
+        @Schema(example = "2025-09-15", description = "모집 시작일 (YYYY-MM-DD)")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @Schema(example = "2025-10-01", description = "모집 종료일 (선택)")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        @NotNull
+        @Schema(description = "모집 상태", example = "OPEN",
+                allowableValues = {"OPEN","CLOSED","ALWAYS"})
+        RecruitmentStatus status,
+
+        @NotBlank @Size(max = 255)
+        @Schema(example = "24기 운영진 모집")
+        String recruitTitle,
+
+        @Schema(description = "모집 상세 설명(선택)")
+        String recruitInfo,
+
+        @Schema(description = "지원 질문(선택)")
+        String question
+) {
+    @AssertTrue(message = "endDate는 startDate보다 빠를 수 없습니다.")
+    public boolean isValidDateRange() {
+        return endDate == null || !endDate.isBefore(startDate);
+    }
+}

--- a/src/main/java/com/jeari/entity/Recruitment.java
+++ b/src/main/java/com/jeari/entity/Recruitment.java
@@ -1,11 +1,14 @@
 package com.jeari.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -13,6 +16,7 @@ import java.time.OffsetDateTime;
 @Getter
 @Setter
 @Entity
+@NoArgsConstructor
 @Table(name = "recruitment")
 public class Recruitment {
 
@@ -25,8 +29,9 @@ public class Recruitment {
     @Column(name = "recruitment_id", nullable = false)
     private Integer id;
 
-    @ColumnDefault("now()")
-    @Column(name = "created_at")
+    // Hibernate가 insert 시점에 자동 세팅
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, columnDefinition = "timestamptz")
     private OffsetDateTime createdAt;
 
     @NotNull
@@ -51,4 +56,34 @@ public class Recruitment {
     @Column(name = "question", length = Integer.MAX_VALUE)
     private String question;
 
+    @Builder
+    public Recruitment(
+            Club club,
+            LocalDate startDate,
+            LocalDate endDate,
+            RecruitmentStatus status,
+            String recruitTitle,
+            String recruitInfo,
+            String question
+    ) {
+        this.club = club;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+        this.recruitTitle = recruitTitle;
+        this.recruitInfo = recruitInfo;
+        this.question = question;
+    }
+
+
+    // 상태 변경
+    public void changeStatus(RecruitmentStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    // 날짜 무결성 간단 체크
+    @AssertTrue(message = "endDate는 startDate보다 빠를 수 없습니다.")
+    private boolean isValidDateRange() {
+        return endDate == null || !endDate.isBefore(startDate);
+    }
 }

--- a/src/main/java/com/jeari/service/RecruitmentService.java
+++ b/src/main/java/com/jeari/service/RecruitmentService.java
@@ -1,0 +1,44 @@
+package com.jeari.service;
+
+import com.jeari.dto.RecruitmentRequest;
+import com.jeari.entity.Club;
+import com.jeari.entity.Recruitment;
+import com.jeari.entity.RecruitmentStatus;
+import com.jeari.repository.ClubRepository;
+import com.jeari.repository.RecruitmentRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class RecruitmentService {
+
+    final private ClubRepository clubRepository;
+    final private RecruitmentRepository recruitmentRepository;
+
+    public Integer createRecruitment(Integer clubId, RecruitmentRequest req) {
+        // 행을 실제로 읽지 않고 FK만 설정하려면 존재 체크 → 프록시 참조 패턴 사용
+        if (!clubRepository.existsById(clubId)) {
+            throw new EntityNotFoundException("동아리 없음: " + clubId);
+        }
+        Club clubRef = clubRepository.getReferenceById(clubId); // SELECT 없이 프록시
+
+        RecruitmentStatus recruitmentStatus = Optional.ofNullable(req.status())
+                .orElse(RecruitmentStatus.OPEN);
+
+        Recruitment recruitment = Recruitment.builder()
+                .club(clubRef)
+                .startDate(req.startDate())   // 또는 req.startDate()
+                .endDate(req.endDate())
+                .status(recruitmentStatus)         // 기본값이 있다면 여기서 지정 가능
+                .recruitTitle(req.recruitTitle())
+                .recruitInfo(req.recruitInfo())
+                .question(req.question())
+                .build();
+
+        return recruitmentRepository.save(recruitment).getId();
+    }
+}

--- a/src/test/java/com/jeari/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/jeari/controller/RecruitmentControllerTest.java
@@ -1,0 +1,84 @@
+package com.jeari.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jeari.dto.RecruitmentRequest;
+import com.jeari.service.RecruitmentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+class RecruitmentControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RecruitmentService recruitmentService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("동아리 모집 공고 생성 - 성공")
+    @WithMockUser(roles = {"USER", "PRESIDENT"})
+    void createRecruitment_success() throws Exception {
+        // given
+        Integer clubId = 1;
+        Integer recruitmentId = 1;
+        RecruitmentRequest request = new RecruitmentRequest(
+                LocalDate.of(2025, 9, 15),
+                LocalDate.of(2025, 9, 30),
+                com.jeari.entity.RecruitmentStatus.OPEN,
+                "신입 부원 모집",
+                "열정적인 신입 부원을 모집합니다.",
+                "자기소개"
+        );
+
+        given(recruitmentService.createRecruitment(eq(clubId), any(RecruitmentRequest.class)))
+                .willReturn(recruitmentId);
+
+        // when & then
+        mockMvc.perform(post("/clubs/{clubId}/recruitments", clubId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.recruitmentId").value(recruitmentId));
+
+        ArgumentCaptor<RecruitmentRequest> captor = ArgumentCaptor.forClass(RecruitmentRequest.class);
+        verify(recruitmentService).createRecruitment(eq(clubId), captor.capture());
+        RecruitmentRequest capturedRequest = captor.getValue();
+        assertThat(capturedRequest.recruitTitle()).isEqualTo(request.recruitTitle());
+    }
+}


### PR DESCRIPTION
- RecruitmentController 생성 및 POST: /clubs/{club id}/recruitment 로직 구현
- RecruitmentReq(DTO) 생성
- spring security에 인가 설정
- RecruitmentService 생성 및 저장 로직 구현
- RecruitmentRepository 생성
- 테스트 코드 작성(RecruitmentControllerTest)